### PR TITLE
Fix: Use Vite environment variables for API_BASE_URL

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=/api

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-const API_BASE_URL = '/api'
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
Closes #4. 

Changes:
- Replaced hardcoded API URL in `frontend/src/services/api.js` with `import.meta.env.VITE_API_BASE_URL`.
- Added `frontend/.env.example` for documentation.
- Ensures the app can be configured for different environments (dev/staging/prod).