### PR TITLE
Fix: Move hardcoded CORS origins to environment variables

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     # Server
     host: str = "0.0.0.0"
     port: int = 8000
+    cors_origins: str = '["http://localhost:5173", "http://localhost:3000", "http://127.0.0.1:5173"]'  # JSON encoded list of origins
     
     # Default language
     default_language: str = "auto"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,10 +12,18 @@ app = FastAPI(
     version="1.0.0"
 )
 
+import json
+
 # Configure CORS for frontend
+try:
+    origins = json.loads(settings.cors_origins)
+except json.JSONDecodeError:
+    origins = ["http://localhost:5173", "http://localhost:3000", "http://127.0.0.1:5173"]
+    print("Warning: Failed to parse CORS_ORIGINS, using defaults")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000", "http://127.0.0.1:5173"],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Closes #3.

Changes:
- Added `cors_origins` configuration to `backend/app/config.py` (parses JSON string from env).
- Updated `backend/app/main.py` to use the configured origins.
- Allows defining allowed origins via `CORS_ORIGINS` environment variable.