### PR TITLE
Fix: Standardize config to ignore extra env vars

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
+        extra = "ignore"
     
     def get_audio_path(self) -> Path:
         path = Path(self.audio_storage_path)


### PR DESCRIPTION
Closes #8.

Changes:
- Updated `backend/app/config.py` to set `extra = 'ignore'` in Pydantic Config.
- Prevents failures when `.env` file contains variables not yet defined in the model (e.g., when switching branches or adding concurrent features).
- Improves robustness of local development environment.